### PR TITLE
fix for bracket is matched but not defined in levels.

### DIFF
--- a/level_test.go
+++ b/level_test.go
@@ -25,11 +25,13 @@ func TestLevelFilter(t *testing.T) {
 	logger.Println("[DEBUG] baz")
 	logger.Println("[WARN] buzz")
 	logger.Println("foobarbaz")
+	logger.Println("[xxxx] foobarbaz")
+	logger.Println(`{"foo":["bar","baz"]}`)
 
 	result := buf.String()
-	expected := "[WARN] foo\n[ERROR] bar\n[WARN] buzz\nfoobarbaz\n"
+	expected := "[WARN] foo\n[ERROR] bar\n[WARN] buzz\nfoobarbaz\n[xxxx] foobarbaz\n{\"foo\":[\"bar\",\"baz\"]}\n"
 	if result != expected {
-		t.Fatalf("bad: %#v", result)
+		t.Fatalf("expected: %#v, bad: %#v", expected, result)
 	}
 }
 


### PR DESCRIPTION
When log messages includes '[...]', previous version disposed the message.