### PR TITLE
fix for with prefix logger

### DIFF
--- a/level.go
+++ b/level.go
@@ -53,7 +53,7 @@ func (f *LevelFilter) getModifierFunc(line []byte) (ModifierFunc, bool) {
 	// Check for a log level
 	var level LogLevel
 	x := bytes.IndexByte(line, '[')
-	if x == 0 {
+	if x >= 0 {
 		y := bytes.IndexByte(line[x:], ']')
 		if y >= 0 {
 			level = LogLevel(line[x+1 : x+y])

--- a/level_test.go
+++ b/level_test.go
@@ -35,6 +35,30 @@ func TestLevelFilter(t *testing.T) {
 	}
 }
 
+func TestLevelFilterWithPrefix(t *testing.T) {
+	buf := new(bytes.Buffer)
+	filter := &LevelFilter{
+		Levels:   []LogLevel{"DEBUG", "WARN", "ERROR"},
+		MinLevel: "WARN",
+		Writer:   buf,
+	}
+
+	logger := log.New(filter, "prefix ", 0)
+	logger.Print("[WARN] foo")
+	logger.Println("[ERROR] bar")
+	logger.Println("[DEBUG] baz")
+	logger.Println("[WARN] buzz")
+	logger.Println("foobarbaz")
+	logger.Println("[xxxx] foobarbaz")
+	logger.Println(`{"foo":["bar","baz"]}`)
+
+	result := buf.String()
+	expected := "prefix [WARN] foo\nprefix [ERROR] bar\nprefix [WARN] buzz\nprefix foobarbaz\nprefix [xxxx] foobarbaz\nprefix {\"foo\":[\"bar\",\"baz\"]}\n"
+	if result != expected {
+		t.Fatalf("expected: %#v, bad: %#v", expected, result)
+	}
+}
+
 func TestLevelFilterCheck(t *testing.T) {
 	filter := &LevelFilter{
 		Levels:   []LogLevel{"DEBUG", "WARN", "ERROR"},


### PR DESCRIPTION
https://github.com/fujiwara/logutils/pull/4

With this support, when using loggers with prefix or shotfile, the log filter no longer works effectively because the first character of the string passed to output is not `[`.

In this PR, the part of the PR where x==0 will be corrected by changing it back to x>=0.